### PR TITLE
fix: preserve file content when delaying due date

### DIFF
--- a/scripts/get_test.go
+++ b/scripts/get_test.go
@@ -561,6 +561,15 @@ This is a test note for delaying.`
 	fileAfterSelection := testFile
 	fileAfterSelection.Content = contentBuilder.String()
 
+	// Save the original implementation to restore after the test
+	originalReadLatestFileContent := readLatestFileContent
+	defer func() { readLatestFileContent = originalReadLatestFileContent }()
+
+	// Mock the readLatestFileContent function to return the file as is
+	readLatestFileContent = func(file File) (File, error) {
+		return file, nil
+	}
+
 	// Mock the file writer that should now trim leading newlines
 	var writtenContent string
 	mockWriteFile := func(file File) error {

--- a/scripts/update.go
+++ b/scripts/update.go
@@ -1,18 +1,99 @@
 package scripts
 
 import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
 type WriteFile = func(File) error
 
+// Make the function a variable so it can be overridden in tests
+var readLatestFileContent = func(file File) (File, error) {
+	// Get the current working directory
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return file, err
+	}
+
+	// Construct the file path
+	filePath := filepath.Join(currentDir, "notes", file.Name)
+
+	// Check if the file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return file, err
+	}
+
+	// Open the file
+	f, err := os.Open(filePath)
+	if err != nil {
+		return file, err
+	}
+	defer f.Close()
+
+	// Read the file and extract content without frontmatter
+	scanner := bufio.NewScanner(f)
+	inFrontmatter := false
+	firstFrontmatterDelimiter := false
+	var contentBuilder strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check for frontmatter delimiters "---"
+		if line == "---" {
+			if !firstFrontmatterDelimiter {
+				// First encountered frontmatter delimiter
+				firstFrontmatterDelimiter = true
+				inFrontmatter = true
+				continue
+			} else if inFrontmatter {
+				// End of frontmatter
+				inFrontmatter = false
+				continue
+			}
+		}
+
+		// Skip frontmatter lines but include everything else
+		if !inFrontmatter {
+			contentBuilder.WriteString(line)
+			contentBuilder.WriteString("\n")
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return file, err
+	}
+
+	// Create a new file struct with the updated content
+	updatedFile := file
+	updatedFile.Content = contentBuilder.String()
+
+	return updatedFile, nil
+}
+
 func DelayDueDate(delayDays int, file File, writeFile WriteFile) error {
+	// Read the latest content from the file to ensure we don't lose any updates
+	updatedFile, err := readLatestFileContent(file)
+	if err != nil {
+		return err
+	}
+
+	// Update the due date on the file with the latest content
 	today := time.Now()
-	file.DueAt = today.AddDate(0, 0, delayDays)
-	return writeFile(file)
+	updatedFile.DueAt = today.AddDate(0, 0, delayDays)
+	return writeFile(updatedFile)
 }
 
 func SetDueDateToToday(file File, writeFile WriteFile) error {
-	file.DueAt = time.Now()
-	return writeFile(file)
+	// Read the latest content from the file to ensure we don't lose any updates
+	updatedFile, err := readLatestFileContent(file)
+	if err != nil {
+		return err
+	}
+
+	updatedFile.DueAt = time.Now()
+	return writeFile(updatedFile)
 }

--- a/scripts/update_test.go
+++ b/scripts/update_test.go
@@ -1,0 +1,122 @@
+package scripts
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDelayDueDatePreservesContent(t *testing.T) {
+	// Setup: Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "notes-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Initial content
+	initialContent := `---
+title: Test Delay Bug
+date-created: 2023-03-05
+tags: [test, bug]
+date-due: 2023-03-05
+done: false
+---
+
+# Test Delay Bug
+
+This is the initial content.`
+
+	// Create initial file on disk
+	fileName := "test-delay-bug.md"
+	filePath := filepath.Join(tempDir, fileName)
+	err = os.WriteFile(filePath, []byte(initialContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write initial file: %v", err)
+	}
+
+	// Step 1: Read the file as it would happen in the application
+	file, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer file.Close()
+
+	// Initial File object as it would be loaded by the application
+	initialFileObj := File{
+		Name:      fileName,
+		Title:     "Test Delay Bug",
+		CreatedAt: time.Date(2023, 3, 5, 0, 0, 0, 0, time.UTC),
+		DueAt:     time.Date(2023, 3, 5, 0, 0, 0, 0, time.UTC),
+		Tags:      []string{"test", "bug"},
+		Done:      false,
+	}
+
+	// Read content from file - this simulates file selection
+	var selectedFileContent strings.Builder
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		selectedFileContent.WriteString(line)
+		selectedFileContent.WriteString("\n")
+	}
+	initialFileObj.Content = selectedFileContent.String()
+
+	// Step 2: Simulate user editing the file in the editor by writing to disk
+	updatedContent := initialContent + "\nThis is new content that was added."
+	err = os.WriteFile(filePath, []byte(updatedContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write updated file: %v", err)
+	}
+
+	// Function to mock reading the latest content from a file
+	// This is what our new readLatestFileContent function should do
+	originalReadLatestFileContent := readLatestFileContent
+	defer func() { readLatestFileContent = originalReadLatestFileContent }()
+
+	readLatestFileContent = func(file File) (File, error) {
+		updatedFile := file
+
+		// Read the content from our test file
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return file, err
+		}
+
+		updatedFile.Content = string(content)
+		return updatedFile, nil
+	}
+
+	// Function to mock writing to file
+	finalContent := ""
+	mockWriteFile := func(file File) error {
+		finalContent = file.Content
+		meta := `---
+title: Test Delay Bug
+date-created: 2023-03-05
+tags: [test, bug]
+date-due: 2023-03-06
+done: false
+---
+
+`
+		content := strings.TrimLeft(file.Content, "\n")
+		return os.WriteFile(filePath, []byte(meta+content), 0644)
+	}
+
+	// The bug should now be fixed - initialFileObj will get updated content
+	err = DelayDueDate(1, initialFileObj, mockWriteFile)
+	if err != nil {
+		t.Fatalf("DelayDueDate returned an error: %v", err)
+	}
+
+	// Check if the update was preserved
+	if strings.Contains(finalContent, "This is new content that was added.") {
+		t.Log("Bug fixed: The update to the note was preserved")
+	} else {
+		t.Error("Bug still exists: The update to the note was lost when delaying it")
+	}
+}


### PR DESCRIPTION
Implement a robust solution to prevent content loss when delaying notes by:
- Adding a new `readLatestFileContent` function to read the most recent file content
- Updating `DelayDueDate` and `SetDueDateToToday` to use the latest file content
- Ensuring any user edits are preserved during date modifications