### PR TITLE
feat: add functionality to retrieve todos by priority levels

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/eiannone/keyboard"
 )
 
-
 func main() {
 	closeChannel := make(chan bool)
 	var searchedFilesStore = data.NewSearchedFilesStore()
@@ -137,6 +136,30 @@ func handleCommand(command presentation.CompletedCommand, onClose func(), fileSt
 			}
 			onFilesFetched(files, fileStore)
 		}
+
+	case "p1":
+		files, err := scripts.GetTodosByPriority(scripts.P1, data.QueryFilesByDone)
+		if err != nil {
+			fmt.Printf("Error getting P1 todos: %v\n", err)
+			return
+		}
+		onFilesFetched(files, fileStore)
+
+	case "p2":
+		files, err := scripts.GetTodosByPriority(scripts.P2, data.QueryFilesByDone)
+		if err != nil {
+			fmt.Printf("Error getting P2 todos: %v\n", err)
+			return
+		}
+		onFilesFetched(files, fileStore)
+
+	case "p3":
+		files, err := scripts.GetTodosByPriority(scripts.P3, data.QueryFilesByDone)
+		if err != nil {
+			fmt.Printf("Error getting P3 todos: %v\n", err)
+			return
+		}
+		onFilesFetched(files, fileStore)
 
 	case "gta":
 		if len(command.Queries) == 0 {


### PR DESCRIPTION
This commit introduces the ability to fetch todos based on their priority (P1, P2, P3) in the main application. Key changes include:
- Added new cases in the command handler to retrieve todos by specified priority.
- Implemented the `GetTodosByPriority` function to filter and sort todos by priority and due date.
- Enhanced test coverage with a new test case for validating the priority retrieval functionality.